### PR TITLE
Get altoclef to go back for furnace

### DIFF
--- a/src/main/java/adris/altoclef/tasks/speedrun/BeatMinecraft2Task.java
+++ b/src/main/java/adris/altoclef/tasks/speedrun/BeatMinecraft2Task.java
@@ -651,6 +651,11 @@ public class BeatMinecraft2Task extends Task {
                     return _gearTask;
                 }
 
+                if (!mod.getItemStorage().hasItem(Items.FURNACE)) {
+                    setDebugState("Going back for furnace after making iron gear.");
+                    return new MineAndCollectTask(Items.FURNACE, 1, new Block[]{Blocks.FURNACE}, MiningRequirement.WOOD);
+                }
+                    
                 // If we happen to find beds...
                 if (needsBeds(mod) && anyBedsFound(mod)) {
                     setDebugState("A bed was found, grabbing that first.");
@@ -662,6 +667,11 @@ public class BeatMinecraft2Task extends Task {
                     _foodTask = new CollectFoodTask(_config.foodUnits);
                     return _foodTask;
                 }
+
+                if (!mod.getItemStorage().hasItem(Items.FURNACE)) {
+                    setDebugState("Going back for furnace after cooking food.");
+                    return new MineAndCollectTask(Items.FURNACE, 1, new Block[]{Blocks.FURNACE}, MiningRequirement.WOOD);
+                }                                 
 
                 // Then get diamond
                 if (!eyeGearSatisfied) {


### PR DESCRIPTION
Gets altoclef to go back for furnace after initially smelting iron gear. This prevents the current situation where it gets a lot of food by walking everywhere and has to walk a very long distance back before it can cook that food at the same furnace.

This commit also makes altoclef go back for the furnace after the food itself is cooked. Otherwise, it would leave the furnace in place, collect diamond ore, and then again travel the very long distance back to be able to re-smelt that diamond ore in the same furnace it cooked the food in.

This commit attempts to help cut down on these repetitive trips.

Seems to work.

Future: (Maybe?) Just craft two or three furnaces to begin with? So that we can just leave them behind. Same for crafting tables.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.